### PR TITLE
QPeek response changed and support for .NET 4

### DIFF
--- a/Disque.Net.Tests/ConnectionTest.cs
+++ b/Disque.Net.Tests/ConnectionTest.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Net.Sockets;
 using Common.Testing.NUnit;
 using FluentAssertions;

--- a/Disque.Net/Disque.Net.csproj
+++ b/Disque.Net/Disque.Net.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Disque.Net</RootNamespace>
     <AssemblyName>Disque.Net</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Disque.Net/Disque.Net.nuspec
+++ b/Disque.Net/Disque.Net.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
 	<metadata>
 		<id>Disque.Net</id>
-		<version>1.0.1</version>
+		<version>1.0.2</version>
 		<authors>ziyasal</authors>
 		<owners>ziyasal</owners>
 		<projectUrl>https://github.com/ziyasal/Disque.Net</projectUrl>
@@ -14,7 +14,4 @@
 			<dependency id="csredis" version="3.2.1" />
 		</dependencies>
 	</metadata>
-	<files>
-    <file src="bin\Release\Disque.Net.dll" target="lib\net451\Disque.Net.dll" />
-	</files>
 </package>

--- a/Disque.Net/DisqueClient.cs
+++ b/Disque.Net/DisqueClient.cs
@@ -168,7 +168,9 @@ namespace Disque.Net
             object[] objects = call as object[];
 
             if (objects != null)
-                result.AddRange(from dynamic o in objects select new Job(queueName, o[0], o[1]));
+            {
+                result.AddRange(from dynamic o in objects select new Job(queueName, o[1], o[2]));
+            }
 
             return result;
         }
@@ -247,7 +249,9 @@ namespace Disque.Net
             object[] objects = response as object[];
 
             if (objects != null)
+            {
                 jobs.AddRange(from dynamic o in objects select new Job(o[0], o[1], o[2]));
+            }
         }
     }
 }

--- a/Disque.Net/packages.config
+++ b/Disque.Net/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="csredis" version="3.2.1" targetFramework="net451" userInstalled="true" />
+  <package id="csredis" version="3.2.1" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
1. DisqueClientTests.Qpeek() test failed with disque 1.0-rc1 because QPeek response changed.
2. Support for .NET 4
