### PR TITLE
Fix methods that take multiple queue names as parameters

### DIFF
--- a/Disque.Net.Tests/ConnectionTest.cs
+++ b/Disque.Net.Tests/ConnectionTest.cs
@@ -14,7 +14,7 @@ namespace Disque.Net.Tests
         [Test]
         public void IterateOverHosts()
         {
-            _q = new DisqueClient(new Uri("disque://192.168.59.103:7711"));
+            _q = new DisqueClient(new Uri(TestConsts.ConnectionString));
             string info = _q.Info();
 
             info.Should().NotBeNullOrEmpty();
@@ -27,7 +27,7 @@ namespace Disque.Net.Tests
         {
             Assert.Throws<SocketException>(() =>
             {
-                _q = new DisqueClient(new Uri("disque://192.168.59.103:55666"));
+                _q = new DisqueClient(new Uri(TestConsts.ConnectionString));
                 _q.Info();
                 _q.Close();
             });

--- a/Disque.Net.Tests/DisqueClientTests.cs
+++ b/Disque.Net.Tests/DisqueClientTests.cs
@@ -99,6 +99,17 @@ namespace Disque.Net.Tests
         }
 
         [Test]
+        public void GetOneJobFromMultipleQueues()
+        {
+            var q1 = GetQueueName();
+            var q2 = GetQueueName();
+            q.AddJob(q1, "q1 msg", 10);
+            q.AddJob(q2, "q2 msg", 10);
+            List<Job> jobs = q.GetJob(new List<string> { q1, q2 });
+            jobs.Count.Should().Be(1);
+        }
+
+        [Test]
         public void AckJob()
         {
             string jobId = q.AddJob(GetQueueName(), "message", 10);
@@ -114,6 +125,16 @@ namespace Disque.Net.Tests
             long count = q.Fastack(jobId);
 
             count.Should().Be(1);
+        }
+
+        [Test]
+        public void FastAckMultiple()
+        {
+            string jobId1 = q.AddJob("fastack", "message1", 10);
+            string jobId2 = q.AddJob("fastack", "message2", 10);
+            long count = q.Fastack(jobId1, jobId2);
+
+            count.Should().Be(2);
         }
 
         [Test]
@@ -191,6 +212,18 @@ namespace Disque.Net.Tests
             string queue = GetQueueName();
             string jobId = q.AddJob(queue, "testJob", 10);
             long count = q.Enqueue(jobId);
+            count.Should().Be(0);
+        }
+
+
+
+        [Test]
+        public void EnqueueMultiple()
+        {
+            string queue = GetQueueName();
+            string jobId1 = q.AddJob(queue, "testJob1", 10);
+            string jobId2 = q.AddJob(queue, "testJob2", 10);
+            long count = q.Enqueue(jobId1, jobId2);
             count.Should().Be(0);
         }
 

--- a/Disque.Net.Tests/DisqueClientTests.cs
+++ b/Disque.Net.Tests/DisqueClientTests.cs
@@ -256,7 +256,6 @@ namespace Disque.Net.Tests
 
 
         [Test]
-        [Ignore("TODO: ")]
         public void Working()
         {
             String queue = GetQueueName();

--- a/Disque.Net.Tests/DisqueClientTests.cs
+++ b/Disque.Net.Tests/DisqueClientTests.cs
@@ -8,6 +8,11 @@ using NUnit.Framework;
 
 namespace Disque.Net.Tests
 {
+    public static class TestConsts
+    {
+        public static string ConnectionString = "disque://192.168.53.129:7711";
+    }
+
     //DOCKERFILE: https://registry.hub.docker.com/u/squiidz/disque/
     public class DisqueClientTests : TestBase
     {
@@ -15,7 +20,7 @@ namespace Disque.Net.Tests
 
         protected override void FinalizeSetUp()
         {
-            q = new DisqueClient(new Uri("disque://192.168.59.103:7711"));
+            q = new DisqueClient(new Uri(TestConsts.ConnectionString));
         }
 
         protected override void FinalizeTearDown()
@@ -78,6 +83,19 @@ namespace Disque.Net.Tests
             q.AddJob(queue, "message", 10);
             List<Job> jobs = q.GetJob(100, 2, new List<string> { queue });
             jobs.Count.Should().Be(2);
+        }
+
+        [Test]
+        public void GetMultipleJobs()
+        {
+            var q1 = GetQueueName();
+            var q2 = GetQueueName();
+            q.AddJob(q1, "q1 msg", 10);
+            q.AddJob(q1, "q1 msg", 10);
+            q.AddJob(q2, "q2 msg", 10);
+            q.AddJob(q2, "q2 msg", 10);
+            List<Job> jobs = q.GetJob(100, 4, new List<string> { q1, q2 });
+            jobs.Count.Should().Be(4);
         }
 
         [Test]

--- a/Disque.Net/DisqueClient.cs
+++ b/Disque.Net/DisqueClient.cs
@@ -241,7 +241,7 @@ namespace Disque.Net
 
         public long Working(string jobId)
         {
-            return (long)_c.Call(Commands.WORKING.ToString());
+            return (long)_c.Call(Commands.WORKING.ToString(), jobId);
         }
 
         public void Close()

--- a/Disque.Net/DisqueClient.cs
+++ b/Disque.Net/DisqueClient.cs
@@ -109,8 +109,13 @@ namespace Disque.Net
         {
             //GETJOB [TIMEOUT <ms-timeout>] [COUNT <count>] FROM queue1 queue2 ... queueN
             var result = new List<Job>();
+            var args = new List<string>
+            {
+                Keywords.FROM.ToString()
+            };
+            args.AddRange(queueNames);
 
-            object call = _c.Call(Commands.GETJOB.ToString(), Keywords.FROM.ToString(), string.Join(" ", queueNames));
+            object call = _c.Call(Commands.GETJOB.ToString(), args.ToArray());
 
             ParseGetJobResponse(call, result);
 
@@ -154,7 +159,7 @@ namespace Disque.Net
 
         public long Ackjob(List<string> jobIdList)
         {
-            return (long)_c.Call(Commands.ACKJOB.ToString(), string.Join(" ", jobIdList));
+            return (long)_c.Call(Commands.ACKJOB.ToString(), jobIdList.ToArray());
         }
 
         public long Ackjob(params string[] jobIds)
@@ -174,11 +179,8 @@ namespace Disque.Net
             object call = _c.Call(Commands.QPEEK.ToString(), queueName, count.ToString());
 
             object[] objects = call as object[];
-
-            if (objects != null)
-            {
-                result.AddRange(from dynamic o in objects select new Job(queueName, o[1], o[2]));
-            }
+            
+            ParseGetJobResponse(objects, result);
 
             return result;
         }
@@ -190,7 +192,7 @@ namespace Disque.Net
 
         public long Dequeue(List<string> jobIdList)
         {
-            return (long)_c.Call(Commands.DEQUEUE.ToString(), string.Join(" ", jobIdList));
+            return (long)_c.Call(Commands.DEQUEUE.ToString(), jobIdList.ToArray());
         }
 
         public long Dequeue(params string[] jobIds)
@@ -200,7 +202,7 @@ namespace Disque.Net
 
         public long Enqueue(List<string> jobIdList)
         {
-            return (long)_c.Call(Commands.ENQUEUE.ToString(), string.Join(" ", jobIdList));
+            return (long)_c.Call(Commands.ENQUEUE.ToString(), jobIdList.ToArray());
         }
 
         public long Enqueue(params string[] jobIds)
@@ -210,7 +212,7 @@ namespace Disque.Net
 
         public long Fastack(List<string> jobIdList)
         {
-            return (long)_c.Call(Commands.FASTACK.ToString(), string.Join(" ", jobIdList));
+            return (long)_c.Call(Commands.FASTACK.ToString(), jobIdList.ToArray());
         }
 
         public long Fastack(params string[] jobIds)
@@ -258,16 +260,13 @@ namespace Disque.Net
 
             if (objects != null)
             {
-                foreach (var item in objects)
-                {
-                    var child = item as object[];
-                    if (child != null)
-                    {
-                        var job = new Job(Conv(child[0]), Conv(child[1]), Conv(child[2]));
-                        jobs.Add(job);
-                    }
-                }
+                jobs.AddRange(ParseJobs(objects));
             }
+        }
+
+        private static IEnumerable<Job> ParseJobs(object[] response)
+        {
+            return response.OfType<object[]>().Select(child => new Job(Conv(child[0]), Conv(child[1]), Conv(child[2])));
         }
 
         private static string Conv(object b)

--- a/Disque.Net/DisqueClient.cs
+++ b/Disque.Net/DisqueClient.cs
@@ -254,9 +254,9 @@ namespace Disque.Net
             _c.Dispose();
         }
 
-        private void ParseGetJobResponse(object response, List<Job> jobs)
+        private static void ParseGetJobResponse(object response, List<Job> jobs)
         {
-            object[] objects = response as object[];
+            var objects = response as object[];
 
             if (objects != null)
             {
@@ -266,18 +266,15 @@ namespace Disque.Net
 
         private static IEnumerable<Job> ParseJobs(object[] response)
         {
-            return response.OfType<object[]>().Select(child => new Job(Conv(child[0]), Conv(child[1]), Conv(child[2])));
+            return response
+                .OfType<object[]>()
+                .Select(child => new Job(Conv(child[0]), Conv(child[1]), Conv(child[2])));
         }
 
         private static string Conv(object b)
         {
             var str = b as string;
-            if (str != null)
-            {
-                return str;
-            }
-
-            return Encoding.UTF8.GetString((byte[])b);
+            return str ?? Encoding.UTF8.GetString((byte[])b);
         }
     }
 }


### PR DESCRIPTION
It seems like the Disque protocol might have been changed since the original implementation of this library.  This can be observed by calling any method that accepts more than a single queue name with multiple names and the call will never return.

The issue affects the following:

- GETJOB
- FASTACK
- ACKJOB
- ENQUEUE
- DEQUEUE

The fix is to append the queue names to the array of method parameters instead of concatenating them into a whitespace separated string.

Beyond the above this PR makes a few additional changes:

- The WORKING method has been implemented fully (it was just missing the job id).
- Gotten rid of the use of `dynamic` for parsing jobs, preferring conditional casts instead.
- Put the connection string to the test Disque instance in a `TestConsts` class.